### PR TITLE
Avoid crashing on short input

### DIFF
--- a/colcolor
+++ b/colcolor
@@ -173,22 +173,23 @@ def main():
     lines = [l_in.rstrip() for l_in in fileinput.input()]
 
     # Automatic header detection; if there are no numbers, a header line.
-    while header or not VPAT.search(lines[0]):
+    while lines and (header or not VPAT.search(lines[0])):
         print(lines.pop(0))
         header = False
 
-    grid, sep = lines_to_grid(lines)
+    if lines:
+        grid, sep = lines_to_grid(lines)
 
-    num_col = max([len(line) for line in grid])
-    columns = [[] for idx in range(num_col)]
-    for row in grid:
-        for col_num, val in enumerate(row):
-            columns[col_num].append(val)
-        for col_num in range(len(row), num_col):
-            columns[col_num].append(None)
+        num_col = max([len(line) for line in grid])
+        columns = [[] for idx in range(num_col)]
+        for row in grid:
+            for col_num, val in enumerate(row):
+                columns[col_num].append(val)
+            for col_num in range(len(row), num_col):
+                columns[col_num].append(None)
 
-    for fancy_line in zip(*map(color_column, columns)):
-        print(sep.join(fancy_line))
+        for fancy_line in zip(*map(color_column, columns)):
+            print(sep.join(fancy_line))
 
 
 if __name__ == '__main__':

--- a/colcolor
+++ b/colcolor
@@ -177,19 +177,21 @@ def main():
         print(lines.pop(0))
         header = False
 
-    if lines:
-        grid, sep = lines_to_grid(lines)
+    if not lines:
+        return
 
-        num_col = max([len(line) for line in grid])
-        columns = [[] for idx in range(num_col)]
-        for row in grid:
-            for col_num, val in enumerate(row):
-                columns[col_num].append(val)
-            for col_num in range(len(row), num_col):
-                columns[col_num].append(None)
+    grid, sep = lines_to_grid(lines)
 
-        for fancy_line in zip(*map(color_column, columns)):
-            print(sep.join(fancy_line))
+    num_col = max([len(line) for line in grid])
+    columns = [[] for idx in range(num_col)]
+    for row in grid:
+        for col_num, val in enumerate(row):
+            columns[col_num].append(val)
+        for col_num in range(len(row), num_col):
+            columns[col_num].append(None)
+
+    for fancy_line in zip(*map(color_column, columns)):
+        print(sep.join(fancy_line))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Hi Eric, thanks for posting colcolor.

My first test happened to be `ls -sh | ./colcolor` in the colcolor directory, and it crashed with
```
Traceback (most recent call last):
  File "/home/m101013/bin/colcolor", line 195, in <module>
    main()
  File "/home/m101013/bin/colcolor", line 176, in main
    while header or not VPAT.search(lines[0]):
IndexError: list index out of range
```
This also happened with ls -Csh.

There were a couple of places that depended on lines[0] after the header search popped all the lines, so I removed those assumptions.

Rob
